### PR TITLE
Handle host segment in UrlConverter

### DIFF
--- a/src/main/java/dev/jbang/launch/UrlConverter.java
+++ b/src/main/java/dev/jbang/launch/UrlConverter.java
@@ -51,21 +51,27 @@ public class UrlConverter {
         
         try {
             URI uri = new URI(url);
-            
+
+            List<String> args = new ArrayList<>();
+            args.add(uri.getScheme()); // Add scheme as first argument
+
+            // Handle host as the first segment, if present
+            if (uri.getHost() != null && !uri.getHost().isEmpty()) {
+                args.add(decode(uri.getHost()));
+            }
+
             String path = uri.getRawPath();
             if (path == null || path.isEmpty()) {
                 throw new IllegalArgumentException("Missing path in " + url);
             }
-            
+
             // Split path into segments and decode each one
-            List<String> args = new ArrayList<>();
-            args.add(uri.getScheme()); // Add scheme as first argument
             for (String segment : path.split("/")) {
                 if (!segment.isEmpty()) {
                     args.add(decode(segment));
                 }
             }
-            
+
             return args;
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid URL: " + url, e);

--- a/src/test/java/dev/jbang/launch/UrlConverterTest.java
+++ b/src/test/java/dev/jbang/launch/UrlConverterTest.java
@@ -1,0 +1,18 @@
+package dev.jbang.launch;
+
+import java.util.List;
+
+public class UrlConverterTest {
+    public static void main(String[] args) {
+        test("jbang://run/hello.java");
+        test("jbang:///run/hello.java");
+    }
+
+    private static void test(String url) {
+        List<String> expected = List.of("jbang", "run", "hello.java");
+        List<String> actual = UrlConverter.urlToCommand(url);
+        if (!actual.equals(expected)) {
+            throw new AssertionError("Expected " + expected + " but was " + actual + " for url: " + url);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix urlToCommand to include host component when converting jbang:// URLs
- add simple executable test verifying URLs with and without host

## Testing
- `mvn -q test` *(fails: Could not resolve plugin maven-resources-plugin)*
- `javac -cp target/classes -d target/test-classes src/test/java/dev/jbang/launch/UrlConverterTest.java && java -cp target/classes:target/test-classes dev.jbang.launch.UrlConverterTest && echo TESTS_OK`


------
https://chatgpt.com/codex/tasks/task_e_6895ab262fb0833381921f7e1d495edb