### PR TITLE
docs: fix typo in protocol handler doc

### DIFF
--- a/PROTOCOL_HANDLER.md
+++ b/PROTOCOL_HANDLER.md
@@ -25,7 +25,7 @@ The intent is to be url to use this url format to run java apps from anywhere wi
 1. When a `jbang://` URL is clicked or accessed, the operating system routes it to `jbang-launch`
 2. `jbang-launch` parses the URL to extract the full jbang command
 3. The parsed information is then processed and for security reasons shown to the user
-4. User can then aceept or decline to run the command.
+4. User can then accept or decline to run the command.
 
 ## Platform Support
 


### PR DESCRIPTION
## Summary
- fix spelling of "accept" in protocol handler documentation

## Testing
- `./mvnw -q test` *(fails: The following artifacts could not be resolved: org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 (absent): Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895ac4d72ec83338d8821d4ff44180e